### PR TITLE
profiles: decouple "board_name" and "profile" from "platform" variable

### DIFF
--- a/files/owut
+++ b/files/owut
@@ -1265,7 +1265,8 @@ function collect_device_info()
 	}
 
 	let target   = sysb.release.target;
-	let platform = replace(sysb.board_name, /,/, "_");
+	let board_name = sysb.board_name;
+	let profile = replace(board_name, /,/, "_");
 	let ver_from = sysb.release.version;
 	let sutype; // Sysupgrade type: combined, combined-efi, sdcard or sysupgrade (or trx or lxl or ???)
 
@@ -1297,11 +1298,12 @@ function collect_device_info()
 	}
 
 	device = {
-		arch:     null,              // "x86_64" or "mipsel_24kc"   or "aarch64_cortex-a53", contained in platform_json
-		target:   target,            // "x86/64" or "ath79/generic" or "mediatek/mt7622", from system board
-		platform: platform,          // "generic" (for x86) or "tplink,archer-c7-v4" or "linksys,e8450-ubi"
-		fstype:   sysb.rootfs_type,  // "ext4" or "squashfs", what is actually present now
-		sutype:   sutype,            // Sysupgrade type, combined, combined-efi or sysupgrade or sdcard
+		arch:       null,              // "x86_64" or "mipsel_24kc"   or "aarch64_cortex-a53", contained in platform_json
+		target:     target,            // "x86/64" or "ath79/generic" or "mediatek/mt7622", from system board
+		board_name: board_name,        // "generic" (for x86) or "tplink,archer-c7-v4" or "linksys,e8450-ubi"
+		profile:    profile,           // "generic", "tplink_archer-c7-v4" or "linksys_e8450-ubi", used to match profiles in profiles.json
+		fstype:     sysb.rootfs_type,  // "ext4" or "squashfs", what is actually present now
+		sutype:     sutype,            // Sysupgrade type, combined, combined-efi or sysupgrade or sdcard
 	};
 
 	build = {
@@ -1362,15 +1364,15 @@ function age(from)
 	return sprintf("~%.0f days ago", hours / 24.0);
 }
 
-function complete_build_info(profile, board)
+function complete_build_info(profiles_json)
 {
-	let dt = gmtime(board.source_date_epoch);
-	build.to.date       = sprintf("%4d-%02d-%02dT%02d:%02d:%02dZ (%s)", dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, age(board.source_date_epoch));
-	build.to.rev_code   = board.version_code;
-	build.to.img_prefix = profile.image_prefix;
+	let dt = gmtime(profiles_json.source_date_epoch);
+	build.to.date       = sprintf("%4d-%02d-%02dT%02d:%02d:%02dZ (%s)", dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, age(profiles_json.source_date_epoch));
+	build.to.rev_code   = profiles_json.version_code;
+	build.to.img_prefix = profiles_json.profiles[device.profile].image_prefix;
 
 	// First, only allow legitimate "sysupgrade" types through.
-	let images = filter(profile.images, (img) => img.filesystem && img.filesystem != "initramfs" && ! match(img.type, /factory/));
+	let images = filter(profiles_json.profiles[device.profile].images, (img) => img.filesystem && img.filesystem != "initramfs" && ! match(img.type, /factory/));
 
 	let valid_fstypes = uniq(sort(map(images, (img) => img.filesystem)));
 	if (! (build.to.fstype in valid_fstypes)) {
@@ -1388,7 +1390,7 @@ function complete_build_info(profile, board)
 			device.sutype = valid_sutypes[0];
 		else
 			L.bug("%s:%s Sysupgrade type '%s' should be one of %s\n",
-				device.target, device.platform, device.sutype, valid_sutypes);
+				device.target, device.profile, device.sutype, valid_sutypes);
 	}
 
 	for (let img in images) {
@@ -1485,16 +1487,19 @@ function collect_platform()
 		L.die("Unsupported target '%s'\n", device.target);
 	}
 
-	if (! (device.platform in keys(platform.profiles))) {
+	if (! (device.profile in keys(platform.profiles))) {
+		// *Although in most cases the board_name (sysinfo:acpi name, dts compatible, custom name) is the
+		// "same" as the profile, and the "sanitization" would be enough to get the proper profile name.
+		// The common/general case is that devices sent any string from the SUPPORTED_DEVICES list and we
+		// need to translate to a proper profile name used by ImageBuilders.
 		// This is a mapped profile, e.g.: raspberrypi,model-b-plus -> rpi
 		let found = false;
-		for (let real_platform, data in platform.profiles) {
-			for (let alias in data.supported_devices) {
-				alias = replace(alias, ",", "_");
-				if (device.platform == alias) {
+		for (let profile, data in platform.profiles) {
+			for (let board_name in data.supported_devices) {
+				if (device.board_name == board_name) {
 					found = true;
-					L.log(2, "Mapping platform %s to %s\n", device.platform, real_platform);
-					device.platform = real_platform;
+					L.log(2, "Mapping platform, board_name to profile: %s to %s\n", device.board_name, profile);
+					device.profile = profile;
 					break;
 				}
 			}
@@ -1502,17 +1507,16 @@ function collect_platform()
 		}
 		if (! found) {
 			if ("generic" in keys(platform.profiles))
-				device.platform = "generic";
+				device.profile = "generic";
 			else
-				L.die("Unsupported profile: %s\n  Valid profiles are %s\n", device.platform, keys(platform.profiles));
+				L.die("Unsupported profile: %s\n  Valid profiles are %s\n", device.profile, keys(platform.profiles));
 		}
 	}
 
-	let profile = platform.profiles[device.platform];
 	device.arch = platform.arch_packages;
 
-	complete_build_info(profile, platform);
-	collect_defaults(platform.default_packages, profile.device_packages);
+	complete_build_info(platform);
+	collect_defaults(platform.default_packages, platform.profiles[device.profile].device_packages);
 
 	if ("linux_kernel" in platform) {
 		build.to.kernel = platform.linux_kernel.version;
@@ -1616,7 +1620,8 @@ function show_config()
 		`ASU-Server     ${url.sysupgrade_root}\n`
 		`Upstream       ${url.upstream}\n`
 		`Target         ${device.target}\n`
-		`Profile        ${device.platform}\n`
+		`Profile        ${device.profile}\n`
+		`Board          ${device.board_name}\n`
 		`Package-arch   ${device.arch}\n`
 	);
 	L.log(1,
@@ -1922,7 +1927,7 @@ function blob(report)
 	let blob = {
 		client:        PROG,
 		target:        device.target,
-		profile:       device.platform,  // sanitized board name
+		profile:       device.profile,  // sanitized board name
 
 		version:       build.to.version,
 		version_code:  rc,


### PR DESCRIPTION
Just separate the, now a bit overloaded, variable "device.platform" which represents: the board_name(dts compatible) and profile into two explicit variables trying to make clearer the profile identification process during ASU sysupgrades.

The old "sanitized" device.platform now would be "device.profile" while the raw board_name is kept in "device.board_name".

In the mapping case code, rename "real_platform" to ~"platform_profile"~ "profile" and "alias" to "board_name" in order to make clearer the translation/mapping being done: board_name -> profile

~Rename standalone "profile" to a more representative "platform_profile" since it represents a tuple from the platform dictionary (profiles.json).~ Removed.

Adapted some log outputs and show the two variables when printing the previous single "device.platform".

No change in the logic, nothing should be different after this change.

EDIT V2: ([compare button](https://github.com/efahl/owut/compare/1abc8ea89ea739e65fa8b1c92cece4ba652c0256..b1c0226ef1012ecb0d5a11e159a1d53181161229))
- Better names for the mapping code,
- Clean-up the another confusing naming in the function "complete_build_info" where the inner "board" argument was representing the full platform (profiles.json), remove the platform_profile which was redundant since we are passing the full platform anyway.