### PR TITLE
owut: allow to append apk repositories to build requests

### DIFF
--- a/files/owut
+++ b/files/owut
@@ -242,6 +242,61 @@ let packages = {  // Dictionary of package lists.
 	replaced:  {}, // Log of replacements and removals due to 'package_changes'.
 };
 
+// Repositories
+const repositories_mode = uci.get('attendedsysupgrade', 'owut', 'repositories_mode') || "append";
+const repository_aliases = uci.get('attendedsysupgrade', 'owut', 'repository_aliases') || [];
+
+let repositories = {};
+let repository_keys = [];
+
+const repository_dir = "/etc/apk/repositories.d";
+const repository_keys_dir = "/etc/apk/keys";
+let repository_files = fs.lsdir(repository_dir);
+const repository_key_files = fs.lsdir(repository_keys_dir);
+let repository_list = [];
+
+if (repository_files) {
+	if (repositories_mode == "append") {
+		repository_files = filter(repository_files, (i) => i != "distfeeds.list");
+	}
+
+	for (let file in repository_files) {
+		let file_path = repository_dir + '/' + file;
+
+		let stat = fs.stat(file_path);
+		if (stat && stat.type === 'file') {
+			let content = fs.readfile(file_path);
+			if (content) {
+				let lines = split(content, "\n");
+				for (let line in lines) {
+					let valid = match(trim(line), /^http/);
+					if (valid) {
+						push(repository_list, line);
+					}
+				}
+			}
+		}
+	}
+}
+
+let use_repositories = length(repository_list) != 0;
+
+if (use_repositories) {
+	if (repository_key_files) {
+		for (let file in repository_key_files) {
+			let file_path = repository_keys_dir + '/' + file;
+
+			let stat = fs.stat(file_path);
+			if (stat && stat.type === 'file') {
+				let content = fs.readfile(file_path);
+				if (content) {
+					push(repository_keys, content)
+				}
+			}
+		}
+	}
+}
+
 //------------------------------------------------------------------------------
 
 const ubus = {
@@ -859,6 +914,65 @@ function branch_of(version)
 	return m ? m[0] : "";
 }
 
+function generate_repositories() {
+	for (let index, repo in repository_list) {
+		let version_from_rx = regexp(build.from.version);
+		let branch_from_rx = regexp(branch_of(build.from.version));
+
+		if (repositories_mode == "replace") {
+			if (build.to.version == "SNAPSHOT") {
+				repo = replace(repo, regexp("/releases/.[^/]*/"), "/snapshots/");
+			} 
+
+			const kmods_path = `${build.to.kernel}-${build.to.kernel_release}-${build.to.kernel_vermagic}`;
+			repo = replace(repo, regexp("/kmods/.[^/]*/"), "/kmods/"+kmods_path+"/");
+			L.log(4, "Adjust kernel modules url': %s\n", repo);			
+		}
+
+		// The repository contains a reference of the from version
+		if (match(repo, version_from_rx)) {
+			repo = replace(repo, build.from.version, build.to.version);
+			L.log(4, "Repository match 'version_from', replaced with 'version_to': %s\n", repo);
+
+		// The repository contains a reference of the from branch
+		} else if (match(repo, branch_from_rx)) {
+			repo = replace(repo, branch_of(build.from.version), branch_of(build.to.version));
+			L.log(4, "Repository match 'branch_from', replaced with 'branch_to': %s\n", repo);
+		}
+
+		for (let alias in repository_aliases) {
+			let pattern = split(alias, " ")[0];
+			let replacement = split(alias, " ")[1];
+			let pattern_rx = regexp(pattern);
+
+			if (match(repo, pattern_rx)) {
+				repo = replace(repo, pattern_rx, replacement)
+			}
+		}
+
+		repositories[index] = repo;
+		repository_list[index] = repo;
+	}
+}
+
+function dl_package_versions_from_repositories()
+{
+	let repositories_packages = {};
+	generate_repositories();
+
+	for (let index, repo in repository_list) {
+		let url = replace(repo, "packages.adb", "index.json");
+		let json = dl_json(url, "/tmp/owut-repositories-packages-"+index+".json", true);
+		repositories_packages = sort({ ...(repositories_packages ?? []), ...(json?.packages ?? []) });
+	}
+
+	if (repositories_mode == "append") {
+		return sort({ ...dl_package_versions(), ...(repositories_packages ?? []) });
+	} else if (repositories_mode == "replace") {
+		return sort({...(repositories_packages ?? []) });
+	}
+}
+
 //------------------------------------------------------------------------------
 //-- Package management --------------------------------------------------------
 
@@ -1181,7 +1295,11 @@ function collect_packages()
 	packages.installed = installed.packages;
 	packages.top_level = sort(keys(top_level.packages));
 
-	packages.available = dl_package_versions() ?? {};  // Might be null in ancient versions.
+	if (use_repositories) {
+		packages.available = dl_package_versions_from_repositories() ?? {};
+	} else {
+		packages.available = dl_package_versions() ?? {};  // Might be null in ancient versions.
+	}
 
 	for (let pkg, ver in packages.installed) {
 		packageDB[pkg] = {
@@ -1563,6 +1681,8 @@ function collect_platform()
 
 	if ("linux_kernel" in platform) {
 		build.to.kernel = platform.linux_kernel.version;
+		build.to.kernel_release = platform.linux_kernel.release;
+		build.to.kernel_vermagic = platform.linux_kernel.vermagic;
 	}
 }
 
@@ -2004,6 +2124,12 @@ function blob(report)
 	if (init_script) {
 		blob.defaults = init_script;
 		L.log(log_level, "  Included init script '%s' (%d bytes) in build request\n", options.init_script, length(init_script));
+	}
+
+	if (use_repositories) {
+		blob.repositories_mode = repositories_mode;
+		blob.repositories = repositories;
+		blob.repository_keys = repository_keys;
 	}
 
 	return blob;

--- a/files/owut.defaults
+++ b/files/owut.defaults
@@ -15,15 +15,17 @@ cat <<CONF >> "$conf_file"
 # '_' underscores.  Use 'owut --help' to see more.
 
 config owut 'owut'
-#	option verbosity         0
-#	option keep              true
-#	option init_script      '/root/data/my-init-script.sh'
-#	option image            '/tmp/my-firmware-img.bin'
-#	option rootfs_size       256
-#	option pre_install      '/etc/owut.d/pre-install.sh'
-#	option poll_interval     10000  # In milliseconds
-#	list   ignored_defaults 'kmod-drm-i915'
-#	list   ignored_defaults 'kmod-dwmac-intel'
+#	option verbosity           0
+#	option keep                true
+#	option init_script        '/root/data/my-init-script.sh'
+#	option image              '/tmp/my-firmware-img.bin'
+#	option rootfs_size         256
+#	option pre_install        '/etc/owut.d/pre-install.sh'
+#	option poll_interval       10000  # In milliseconds
+#	option repositories_mode  'append'
+#	list   repository_aliases 'SNAPSHOT main'
+#	list   ignored_defaults   'kmod-drm-i915'
+#	list   ignored_defaults   'kmod-dwmac-intel'
 
 CONF
 echo "Please see owut section of $conf_file for example options."


### PR DESCRIPTION
Implemented only for apk for simplicity.

With these changes owut will try to use additional repositories
and repository_keys found in /etc/apk/repositories.d and /etc/apk/keys
when submitting build requests to an asu server.

Mini how-to:
1. Set up your custom feeds:
```
echo "https://my.repo/packages.adb" >> /etc/apk/repositories.d/customfeeds.list
wget https://my.repo/my-keys.pem -O /etc/apk/keys/my-keys.pem
```
2. Verify that they work with apk:
```
apk update && apk verify /tmp/cache/apk/*
```

3. The server must allow the extra repos for the build to succed:
The server can be checked by viewing the overview JSON file, like:
```
curl -s https://sysupgrade.libremesh.org/json/v1/overview.json \
        | jq .server.repository_allow_list
```

4. Confirm that owut is working with the additional repositories:
```
owut check
```

[Note]
Currently the repositories must expose via webserver an 'index.json' in the same
folder as the apk's index file 'packages.adb'

As an example if you own the directory that expose built packages note that it can
be generated with apk
```
apk adbdump --format json packages.adb > index.json
```

[Note]
A local generation of the index.json is possible and can be added later but
requires apk installed.
While the directory /etc/apk with repositories.d and keys is created also if
apk-mbedtls is not installed on the device.

**repositories_mode**
The openwrt default feeds contained in /etc/apk/repositories.d/distfeeds.list
are read only if the uci option `attendedsysupgrade.owut.repositories_mode="replace"`
is set.

**repository_aliases**
If the additional repository that you are adding expose packages organized in paths
that contains a reference of the **version** or the **branch** for which they are
built, in both repositories_mode `append` (default) and `replace` owut will try to
guess the new repositories from the existing ones, by replacing the `version_from`
with the new `version_to` and, if not found, the `branch_from` with the `branch_to`.

You can obviously insert the correct URL to use for the upgrade in
/etc/apk/repositories.d/customfeeds.list (which could indeed differ from the one you
were using to install packages via apk with your current version).

Custom adjustments for the paths of the new repositories could be made setting
an uci list of `attendedsysupgrade.owut.repository_aliases` to meet the need to
accommodate various models for organising the directories of compiled packages.

As an example the replacement of `/releases/.[^/]*/` to `/snapshots/` is
hardcoded when running `owut -V SNAPSHOT` and setting repositories_mode="replace"
but it could be obtained by setting up an custom alias like:
```
uci add_list attendedsysupgrade.owut.repository_aliases="/releases/.[^/]*/ /snapshots/"
```